### PR TITLE
Rails 4 beta support

### DIFF
--- a/lodash-rails.gemspec
+++ b/lodash-rails.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.email = ['richard.hubers@gmail.com']
   s.date = Time.now.strftime('%Y-%m-%d')
   s.require_paths = ['lib']
-  s.add_dependency('railties', '~> 3.1')
+  s.add_dependency('railties', '>= 3.1')
   s.files = Dir["{lib,vendor}/**/*"] + ["README.md"]
   s.homepage = 'http://github.com/rh/lodash-rails'
   s.license = 'MIT'


### PR DESCRIPTION
Depend on railties >= 3.1, seems to work fine, there are no changes to railties that should affect this gem: http://edgeguides.rubyonrails.org/4_0_release_notes.html#railties
